### PR TITLE
Choose "a" or "an" before system name.

### DIFF
--- a/lex.sh
+++ b/lex.sh
@@ -22,7 +22,15 @@ thesystem=${thefile/images/}
 thesystem=${thesystem/\//}
 thesystem=${thesystem//_/ }
 thesystem=${thesystem/\.[a-z][a-z][a-z]/}
-# "it's a Unix system, I know this"
-convert merged.png \( -background black -fill yellow -font Helvetica -pointsize 48 -gravity center label:"This is a ${thesystem} system,\nI know this!" \) -gravity south -compose over -composite merged_final.png
+if ! [[ "${thesystem,,}" =~ ^unix ]] && \
+    ([[ "${thesystem,,}" =~ ^[aeiou] ]] || [[ "${thesystem,,}" =~ ^lcars ]]); then
+    
+    thearticle=an
+else
+    thearticle=a
+fi
 
-echo $thesystem > systemname.txt
+# "it's a Unix system, I know this"
+convert merged.png \( -background black -fill yellow -font Helvetica -pointsize 48 -gravity center label:"This is ${thearticle} ${thesystem} system,\nI know this!" \) -gravity south -compose over -composite merged_final.png
+
+echo $thearticle $thesystem > systemname.txt

--- a/omgno.R
+++ b/omgno.R
@@ -38,7 +38,7 @@ token <- readRDS("rtoot_token.rds")
 
 # post the file to botsin.space
 post_toot(token = token, status = "", media="merged_final.png",
-          alt_text = paste("shot from Jurassic Park where Lex is sitting in front of the computer but it's not a unix system, it's a",  readLines("systemname.txt"), "system"))
+          alt_text = paste("shot from Jurassic Park where Lex is sitting in front of the computer but it's not a unix system, it's",  readLines("systemname.txt"), "system"))
 
 
 


### PR DESCRIPTION
Your bot made me smile, so I thought it might be nice to use "a" or "an" grammatically before the system name. For example, "This is a Raspian system," or "This is an Ubuntu system." I also added special cases for "This is an LCARS system," and "This is a UnixWare 1.0 system."